### PR TITLE
Fix version metadata misalignment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
 
 setup(
     name='octconv',
-    version=os.getenv('TRAVIS_TAG', '0.1.0'),
+    version=os.getenv('TRAVIS_TAG', '0.2.0'),
     packages=['octconv'],
     url='https://github.com/braincreators/octconv',
     license='MIT',


### PR DESCRIPTION
Installing the latest version by from PyPI, using `pip install octconv==0.2.0`, fails with the following error.
```
Collecting octconv==0.2.0
  Using cached octconv-0.2.0.tar.gz (4.3 kB)
  Preparing metadata (setup.py) ... done
  WARNING: Requested octconv==0.2.0 from https://files.pythonhosted.org/packages/33/c7/b5ea3d12ba1954e48d9bc5beaf998bcc11478483a76452c5fbdbfe588a6d/octconv-0.2.0.tar.gz, but installing version 0.1.0
Discarding https://files.pythonhosted.org/packages/33/c7/b5ea3d12ba1954e48d9bc5beaf998bcc11478483a76452c5fbdbfe588a6d/octconv-0.2.0.tar.gz (from https://pypi.org/simple/octconv/): Requested octconv==0.2.0 from https://files.pythonhosted.org/packages/33/c7/b5ea3d12ba1954e48d9bc5beaf998bcc11478483a76452c5fbdbfe588a6d/octconv-0.2.0.tar.gz has inconsistent version: expected '0.2.0', but metadata has '0.1.0'
ERROR: Could not find a version that satisfies the requirement octconv==0.2.0 (from versions: 0.1.0, 0.2.0)
ERROR: No matching distribution found for octconv==0.2.0
```
This patch attempts to fix this error, by updating the version metadata to 0.2.0.
